### PR TITLE
minigrep

### DIFF
--- a/minigrep/src/main.rs
+++ b/minigrep/src/main.rs
@@ -7,12 +7,12 @@ fn main () {
     let arguments_vector : Vec<String> = env::args().collect();
 
     let config = Config::build(&arguments_vector).unwrap_or_else(|err| {
-        println!("Problem parsing arguments: {}", err);
+        eprintln!("Problem parsing arguments: {}", err);
         process::exit(1);
     });
 
     if let Err(message) = minigrep::run(&config) {
-        println!("Application Error: {}", message);
+        eprintln!("Application Error: {}", message);
         process::exit(1);
     }
 }


### PR DESCRIPTION
- case in sensitive search through environment variable
- print the error to standard error.
